### PR TITLE
A deployment is sent to only one node

### DIFF
--- a/zosreq/req_deployment_root.v
+++ b/zosreq/req_deployment_root.v
@@ -49,7 +49,6 @@ pub struct RequestItem {
 pub mut:
 	// unique name per Deployment
 	name     string
-	node_id  int
 	category Category
 	// in epoch format
 	json_data string


### PR DESCRIPTION
While the deployment has multiple workloads, a single deployment is sent to a single node only.

Nodes don't support orchestrating multiple nodes setup. Implementing this on server side is gonna be a lot of pain. instead it should be orchestrated by the client as following (same as we do with 2.x)
- A client design his multi node deployment
- A client creates smaller deployments (can has multiple workloads) and send to each node separated in his setup
- A node cares only about its own workloads.

Deployment data on the blockchain should be encrypted in a way that this specific node should be the only once that can read it (asymmetric encryption) this is okay because:
- Deployments are not migrateble, there are many things that is very node specific like the network resource configuration and free ports.
- If a user wants to move a deployment to another node, he must first delete his contract for this deployment first, then recreate a new one
- Since a deployment might have user sensitive data (wireguard keys) a deployment should only be readable by the node only.